### PR TITLE
fix: mariadb 예약어 (key) 이슈 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MariaDB106Dialect
     open-in-view: false
+    properties:
+      hibernate:
+        globally_quoted_identifiers: true
 
 static:
   paths:


### PR DESCRIPTION
### Issue

MariaDB의 VerificationToken 테이블의 key라는 컬럼이 예약어라서 ORM이 정상적으로 동작하지 않았습니다.
-> 토큰 인증 관련 서비스가 정상적으로 동작하지 않는 이슈 발생

### 해결

`hibernate.globally_quoted_identifiers=true`를 적용해서 모든 Table 및 Column name에 식별자를 사용하도록 수정했습니다.

Refer
- hibernate.globally_quoted_identifiers=true

> TDD를 하면서 테스트에서만 확인했는데, 테스트에서는 DB가 달라서 해당 이슈가 발생이 안되었네요.. ㅠ ㅠ!

@Bigstar1108 